### PR TITLE
Add dex twap query lib

### DIFF
--- a/packages/sei-cosmwasm/examples/schema.rs
+++ b/packages/sei-cosmwasm/examples/schema.rs
@@ -3,7 +3,8 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 use sei_cosmwasm::{
-    ExchangeRatesResponse, SeiMsg, SeiMsgWrapper, SeiQuery, SeiQueryWrapper, SeiRoute,
+    DexTwapsResponse, ExchangeRatesResponse, OracleTwapsResponse, SeiMsg, SeiMsgWrapper, SeiQuery,
+    SeiQueryWrapper, SeiRoute,
 };
 
 fn main() {
@@ -18,4 +19,6 @@ fn main() {
     export_schema(&schema_for!(SeiQuery), &out_dir);
     export_schema(&schema_for!(SeiRoute), &out_dir);
     export_schema(&schema_for!(ExchangeRatesResponse), &out_dir);
+    export_schema(&schema_for!(OracleTwapsResponse), &out_dir);
+    export_schema(&schema_for!(DexTwapsResponse), &out_dir);
 }

--- a/packages/sei-cosmwasm/src/lib.rs
+++ b/packages/sei-cosmwasm/src/lib.rs
@@ -6,8 +6,8 @@ mod route;
 pub use msg::{SeiMsg, SeiMsgWrapper};
 pub use querier::SeiQuerier;
 pub use query::{
-    DenomOracleExchangeRatePair, ExchangeRatesResponse, OracleExchangeRate, OracleTwapsResponse,
-    SeiQuery, SeiQueryWrapper,
+    DenomOracleExchangeRatePair, DexPair, DexTwap, DexTwapsResponse, ExchangeRatesResponse,
+    OracleExchangeRate, OracleTwap, OracleTwapsResponse, SeiQuery, SeiQueryWrapper,
 };
 pub use route::SeiRoute;
 

--- a/packages/sei-cosmwasm/src/querier.rs
+++ b/packages/sei-cosmwasm/src/querier.rs
@@ -1,6 +1,8 @@
 use cosmwasm_std::{QuerierWrapper, StdResult};
 
-use crate::query::{ExchangeRatesResponse, OracleTwapsResponse, SeiQuery, SeiQueryWrapper};
+use crate::query::{
+    DexTwapsResponse, ExchangeRatesResponse, OracleTwapsResponse, SeiQuery, SeiQueryWrapper,
+};
 use crate::route::SeiRoute;
 
 /// This is a helper wrapper to easily use our custom queries
@@ -27,6 +29,23 @@ impl<'a> SeiQuerier<'a> {
         let request = SeiQueryWrapper {
             route: SeiRoute::Oracle,
             query_data: SeiQuery::OracleTwaps { lookback_seconds },
+        }
+        .into();
+
+        self.querier.query(&request)
+    }
+
+    pub fn query_dex_twaps(
+        &self,
+        lookback_seconds: u64,
+        contract_address: String,
+    ) -> StdResult<DexTwapsResponse> {
+        let request = SeiQueryWrapper {
+            route: SeiRoute::Dex,
+            query_data: SeiQuery::DexTwaps {
+                contract_address,
+                lookback_seconds,
+            },
         }
         .into();
 

--- a/packages/sei-cosmwasm/src/query.rs
+++ b/packages/sei-cosmwasm/src/query.rs
@@ -20,7 +20,13 @@ impl CustomQuery for SeiQueryWrapper {}
 #[serde(rename_all = "snake_case")]
 pub enum SeiQuery {
     ExchangeRates {},
-    OracleTwaps { lookback_seconds: i64 },
+    OracleTwaps {
+        lookback_seconds: i64,
+    },
+    DexTwaps {
+        contract_address: String,
+        lookback_seconds: u64,
+    },
 }
 
 /// ExchangeRateItem is data format returned from OracleRequest::ExchangeRates query
@@ -50,8 +56,27 @@ pub struct OracleTwap {
     lookback_seconds: i64,
 }
 
-/// OracleTwapsResponse is data format returned from OracleRequest::ExchangeRates query
+/// OracleTwapsResponse is data format returned from OracleRequest::OracleTwaps query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OracleTwapsResponse {
     pub oracle_twaps: Vec<OracleTwap>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct DexPair {
+    price_denom: i32, // TODO: change to string after sei changes denom representation
+    asset_denom: i32, // TODO: change to string after sei changes denom representation
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct DexTwap {
+    pair: DexPair,
+    twap: Decimal,
+    look_back_seconds: u64,
+}
+
+/// DexTwapsResponse is data format returned from DexTwaps query
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct DexTwapsResponse {
+    pub twaps: Vec<DexTwap>,
 }

--- a/packages/sei-cosmwasm/src/route.rs
+++ b/packages/sei-cosmwasm/src/route.rs
@@ -6,4 +6,5 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "snake_case")]
 pub enum SeiRoute {
     Oracle,
+    Dex,
 }


### PR DESCRIPTION
Add library function to query `dex` TWAP from sei. Also fixed some minor export issues.

Tested on local chain with local vortex deploy. No good way to test this via unit test