### PR TITLE
enable `sei` feature for wasm contracts

### DIFF
--- a/packages/sei-cosmwasm/src/lib.rs
+++ b/packages/sei-cosmwasm/src/lib.rs
@@ -15,8 +15,7 @@ pub use query::{
 };
 pub use route::SeiRoute;
 
-// TODO: properly support this requirement behavior in sei-chain
-// // This export is added to all contracts that import this package, signifying that they require
-// // "sei" support on the chain they run on.
-// #[no_mangle]
-// extern "C" fn requires_sei() {}
+// This export is added to all contracts that import this package, signifying that they require
+// "sei" support on the chain they run on.
+#[no_mangle]
+extern "C" fn requires_sei() {}


### PR DESCRIPTION
in `packages/sei-cosmwasm/src/lib.rs`, there is [the following TODO item](https://github.com/sei-protocol/sei-cosmwasm/blob/1bf3aeebbce891265f715dd7e5b6d4c117992b1a/packages/sei-cosmwasm/src/lib.rs#L18-L22):

```rust
// TODO: properly support this requirement behavior in sei-chain
// // This export is added to all contracts that import this package, signifying that they require
// // "sei" support on the chain they run on.
// #[no_mangle]
// extern "C" fn requires_sei() {}
```

this feature is enabled in https://github.com/sei-protocol/sei-chain/pull/115, so these lines can be uncommented and the TODO item removed.