### PR TITLE
Update Denom Type from i32 to String

### DIFF
--- a/packages/sei-cosmwasm/src/proto_structs.rs
+++ b/packages/sei-cosmwasm/src/proto_structs.rs
@@ -26,8 +26,8 @@ pub struct OracleTwap {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DexPair {
-    pub price_denom: i32, // TODO: change to string after sei changes denom representation
-    pub asset_denom: i32, // TODO: change to string after sei changes denom representation
+    pub price_denom: String,
+    pub asset_denom: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]


### PR DESCRIPTION
- `Dex` Module in Sei represents Denoms as Strings
- Vortex contracts will also represent Denoms as Strings (vs enums)
- Updates DexPair to Strings for each denom

One issue is that we need to be careful with merging this PR and how it affects the current vortex contract