### PR TITLE
Remove signers from dex wasmbinding messages

### DIFF
--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -42,7 +42,7 @@ pub fn execute(
 
 pub fn place_orders(
     _deps: DepsMut,
-    env: Env,
+    _env: Env,
     _info: MessageInfo,
 ) -> Result<Response<SeiMsg>, StdError> {
     let order_placement = Order {
@@ -56,8 +56,6 @@ pub fn place_orders(
         status_description: "".to_string(),
     };
     let test_order = sei_cosmwasm::SeiMsg::PlaceOrders {
-        creator: env.contract.address.clone(),
-        contract_address: env.contract.address,
         funds: vec![],
         orders: vec![order_placement],
     };
@@ -66,13 +64,11 @@ pub fn place_orders(
 
 pub fn cancel_orders(
     _deps: DepsMut,
-    env: Env,
+    _env: Env,
     _info: MessageInfo,
     order_ids: Vec<u64>,
 ) -> Result<Response<SeiMsg>, StdError> {
     let test_cancel = sei_cosmwasm::SeiMsg::CancelOrders {
-        creator: env.contract.address.clone(),
-        contract_address: env.contract.address,
         order_ids,
     };
     Ok(Response::new().add_message(test_cancel))

--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -68,9 +68,7 @@ pub fn cancel_orders(
     _info: MessageInfo,
     order_ids: Vec<u64>,
 ) -> Result<Response<SeiMsg>, StdError> {
-    let test_cancel = sei_cosmwasm::SeiMsg::CancelOrders {
-        order_ids,
-    };
+    let test_cancel = sei_cosmwasm::SeiMsg::CancelOrders { order_ids };
     Ok(Response::new().add_message(test_cancel))
 }
 

--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -42,7 +42,7 @@ pub fn execute(
 
 pub fn place_orders(
     _deps: DepsMut,
-    _env: Env,
+    env: Env,
     _info: MessageInfo,
 ) -> Result<Response<SeiMsg>, StdError> {
     let order_placement = Order {
@@ -58,17 +58,21 @@ pub fn place_orders(
     let test_order = sei_cosmwasm::SeiMsg::PlaceOrders {
         funds: vec![],
         orders: vec![order_placement],
+        contract_address: env.contract.address,
     };
     Ok(Response::new().add_message(test_order))
 }
 
 pub fn cancel_orders(
     _deps: DepsMut,
-    _env: Env,
+    env: Env,
     _info: MessageInfo,
     order_ids: Vec<u64>,
 ) -> Result<Response<SeiMsg>, StdError> {
-    let test_cancel = sei_cosmwasm::SeiMsg::CancelOrders { order_ids };
+    let test_cancel = sei_cosmwasm::SeiMsg::CancelOrders {
+        order_ids,
+        contract_address: env.contract.address,
+    };
     Ok(Response::new().add_message(test_cancel))
 }
 

--- a/packages/sei-cosmwasm/README.md
+++ b/packages/sei-cosmwasm/README.md
@@ -66,6 +66,7 @@ To use the custom messages, the messages need to be returned in the contract res
 
 ```rust
 let test_order = sei_cosmwasm::SeiMsg::PlaceOrders {
+    contract_address: env.contract.address,
     funds: vec![some_funds],
     orders: vec![some_order],
 };

--- a/packages/sei-cosmwasm/README.md
+++ b/packages/sei-cosmwasm/README.md
@@ -66,8 +66,6 @@ To use the custom messages, the messages need to be returned in the contract res
 
 ```rust
 let test_order = sei_cosmwasm::SeiMsg::PlaceOrders {
-    creator: creator_address,
-    contract_address: env.contract.address,
     funds: vec![some_funds],
     orders: vec![some_order],
 };

--- a/packages/sei-cosmwasm/src/msg.rs
+++ b/packages/sei-cosmwasm/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::sei_types::Order;
-use cosmwasm_std::{Coin, CosmosMsg, CustomMsg};
+use cosmwasm_std::{Addr, Coin, CosmosMsg, CustomMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -19,9 +19,11 @@ pub enum SeiMsg {
     PlaceOrders {
         orders: Vec<Order>,
         funds: Vec<Coin>,
+        contract_address: Addr,
     },
     CancelOrders {
         order_ids: Vec<u64>,
+        contract_address: Addr,
     },
     CreateDenom {
         subdenom: String,

--- a/packages/sei-cosmwasm/src/msg.rs
+++ b/packages/sei-cosmwasm/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::sei_types::Order;
-use cosmwasm_std::{Addr, Coin, CosmosMsg, CustomMsg};
+use cosmwasm_std::{Coin, CosmosMsg, CustomMsg};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -17,15 +17,11 @@ impl From<SeiMsg> for CosmosMsg<SeiMsg> {
 #[serde(rename_all = "snake_case")]
 pub enum SeiMsg {
     PlaceOrders {
-        creator: Addr,
         orders: Vec<Order>,
-        contract_address: Addr,
         funds: Vec<Coin>,
     },
     CancelOrders {
-        creator: Addr,
         order_ids: Vec<u64>,
-        contract_address: Addr,
     },
     CreateDenom {
         subdenom: String,


### PR DESCRIPTION
- Removes `ContractAddr` and `Creator` from dex messages