### PR TITLE
Add example for finalize block

### DIFF
--- a/contracts/sei-tester/deployment/deployment_script.sh
+++ b/contracts/sei-tester/deployment/deployment_script.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+echo -n Customized sei-tester Contract \(../../artifacts/sei_tester.wasm by default\):
+read contract
+echo
+echo -n Customized Key Name:\(admin by default\)
+read keyname
+echo
+echo -n Keyring Password:\(12345678 by default\)
+read password
+echo
+
+if [ -z "${contract}" ];
+then contract=../../artifacts/sei_tester.wasm
+fi 
+if [ -z "${keyname}" ];
+then keyname=admin
+fi 
+if [ -z "${password}" ];
+then password="12345678\n"
+fi 
+
+seid=~/go/bin/seid
+code=$(printf $password | $seid tx wasm store $contract -y --from=$keyname --chain-id=sei-chain --gas=10000000 --fees=10000000usei --broadcast-mode=block | grep -A 1 "code_id" | sed -n 's/.*value: "//p' | sed -n 's/"//p')
+admin_addr=$(printf $password |$seid keys show $keyname | grep -A 1 "address" | sed -n 's/.*address: //p')
+
+addr=$(printf $password |$seid tx wasm instantiate $code "{}" --from $keyname --broadcast-mode=block --label "vortex" --no-admin --chain-id sei-chain --gas=30000000 --fees=300000usei -y | grep -A 1 -m 1 "key: _contract_address" | sed -n 's/.*value: //p' | xargs)
+
+printf $password |$seid tx dex register-contract $addr $code true true -y --from=$keyname --chain-id=sei-chain --fees=10000000usei --gas=10000000 --broadcast-mode=block
+
+printf "\n\nDeployed sei tester contract address is %s\n" $addr

--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -8,7 +8,7 @@ use crate::{
         BulkOrderPlacementsResponse, DepositInfo, ExecuteMsg, InstantiateMsg, LiquidationRequest,
         LiquidationResponse, QueryMsg, SettlementEntry, SudoMsg,
     },
-    types::{OrderData, PositionEffect, ContractOrderResult},
+    types::{ContractOrderResult, OrderData, PositionEffect},
 };
 use sei_cosmwasm::{
     DexTwapsResponse, EpochResponse, ExchangeRatesResponse, GetOrderByIdResponse,
@@ -136,7 +136,9 @@ pub fn sudo(deps: DepsMut<SeiQueryWrapper>, env: Env, msg: SudoMsg) -> Result<Re
         }
         SudoMsg::BulkOrderCancellations { ids } => process_bulk_order_cancellations(deps, ids),
         SudoMsg::Liquidation { requests } => process_bulk_liquidation(deps, env, requests),
-        SudoMsg::FinalizeBlock { contract_order_results } => process_finalize_block(deps, env, contract_order_results),
+        SudoMsg::FinalizeBlock {
+            contract_order_results,
+        } => process_finalize_block(deps, env, contract_order_results),
     }
 }
 
@@ -219,13 +221,22 @@ pub fn process_finalize_block(
 
     // print order placement results
     for order_results in contract_order_results {
-        deps.api.debug(&format!("Order results from contract {}", order_results.contract_address));
-        
+        deps.api.debug(&format!(
+            "Order results from contract {}",
+            order_results.contract_address
+        ));
+
         for order_placement in order_results.order_placement_results {
-            deps.api.debug(&format!("Order id {}, status {}", order_placement.order_id, order_placement.status_code));
+            deps.api.debug(&format!(
+                "Order id {}, status {}",
+                order_placement.order_id, order_placement.status_code
+            ));
         }
         for order_execution in order_results.order_execution_results {
-            deps.api.debug(&format!("Order id {}, executed_quantity {}", order_execution.order_id, order_execution.executed_quantity));
+            deps.api.debug(&format!(
+                "Order id {}, executed_quantity {}",
+                order_execution.order_id, order_execution.executed_quantity
+            ));
         }
     }
 

--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -8,7 +8,7 @@ use crate::{
         BulkOrderPlacementsResponse, DepositInfo, ExecuteMsg, InstantiateMsg, LiquidationRequest,
         LiquidationResponse, QueryMsg, SettlementEntry, SudoMsg,
     },
-    types::{OrderData, PositionEffect},
+    types::{OrderData, PositionEffect, ContractOrderResult},
 };
 use sei_cosmwasm::{
     DexTwapsResponse, EpochResponse, ExchangeRatesResponse, GetOrderByIdResponse,
@@ -136,6 +136,7 @@ pub fn sudo(deps: DepsMut<SeiQueryWrapper>, env: Env, msg: SudoMsg) -> Result<Re
         }
         SudoMsg::BulkOrderCancellations { ids } => process_bulk_order_cancellations(deps, ids),
         SudoMsg::Liquidation { requests } => process_bulk_liquidation(deps, env, requests),
+        SudoMsg::FinalizeBlock { contract_order_results } => process_finalize_block(deps, env, contract_order_results),
     }
 }
 
@@ -206,6 +207,29 @@ pub fn process_bulk_liquidation(
 
     let mut response: Response = Response::new();
     response = response.set_data(binary);
+    Ok(response)
+}
+
+pub fn process_finalize_block(
+    deps: DepsMut<SeiQueryWrapper>,
+    _env: Env,
+    contract_order_results: Vec<ContractOrderResult>,
+) -> Result<Response, StdError> {
+    deps.api.debug("Processing finalize block...");
+
+    // print order placement results
+    for order_results in contract_order_results {
+        deps.api.debug(&format!("Order results from contract {}", order_results.contract_address));
+        
+        for order_placement in order_results.order_placement_results {
+            deps.api.debug(&format!("Order id {}, status {}", order_placement.order_id, order_placement.status_code));
+        }
+        for order_execution in order_results.order_execution_results {
+            deps.api.debug(&format!("Order id {}, executed_quantity {}", order_execution.order_id, order_execution.executed_quantity));
+        }
+    }
+
+    let response = Response::new();
     Ok(response)
 }
 

--- a/contracts/sei-tester/src/msg.rs
+++ b/contracts/sei-tester/src/msg.rs
@@ -3,6 +3,8 @@ use schemars::JsonSchema;
 use sei_cosmwasm::{Order, OrderType, PositionDirection};
 use serde::{Deserialize, Serialize};
 
+use crate::types::ContractOrderResult;
+
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct InstantiateMsg {}
 
@@ -83,6 +85,10 @@ pub enum SudoMsg {
 
     Liquidation {
         requests: Vec<LiquidationRequest>,
+    },
+
+    FinalizeBlock {
+        contract_order_results: Vec<ContractOrderResult>,
     },
 }
 

--- a/contracts/sei-tester/src/types.rs
+++ b/contracts/sei-tester/src/types.rs
@@ -15,3 +15,24 @@ pub enum PositionEffect {
     Open,
     Close,
 }
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ContractOrderResult {
+    pub contract_address: String,
+    pub order_placement_results: Vec<OrderPlacementResult>,
+    pub order_execution_results: Vec<OrderExecutionResult>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct OrderPlacementResult {
+    pub order_id: u64,
+    pub status_code: i32,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct OrderExecutionResult {
+    pub order_id: u64,
+    pub execution_price: Decimal,
+    pub executed_quantity: Decimal,
+    pub total_notional: Decimal,
+    pub position_direction: String,
+}


### PR DESCRIPTION
Add example for finalize block. 

To be noted:
- you need to register the contract as needHook=true into the dex module, only then the finalized_block sudo endpoint will be called in the endblock
- only order status of orders placed by the contract will be returned in the finalized_block