### PR TITLE
Remove Eq serde

### DIFF
--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -60,7 +60,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          args: -- -W warnings
 
       - name: Generate Schema For sei-tester
         uses: actions-rs/cargo@v1

--- a/contracts/sei-tester/src/msg.rs
+++ b/contracts/sei-tester/src/msg.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, JsonSchema)]
 pub struct InstantiateMsg {}
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     PlaceOrders {},
@@ -16,7 +16,7 @@ pub enum ExecuteMsg {
     ChangeAdmin {},
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     ExchangeRates {},

--- a/contracts/sei-tester/src/types.rs
+++ b/contracts/sei-tester/src/types.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // example of a contract specific order data struct
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OrderData {
     pub leverage: Decimal,
     pub position_effect: PositionEffect,

--- a/packages/sei-cosmwasm/Cargo.toml
+++ b/packages/sei-cosmwasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sei-cosmwasm"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 description = "Bindings and helpers for cosmwasm contracts to interact with sei blockchain"
 license = "Apache-2.0"

--- a/packages/sei-cosmwasm/README.md
+++ b/packages/sei-cosmwasm/README.md
@@ -8,7 +8,7 @@ Add the sei-cosmwasm dependency to your smart contract's `Cargo.toml` file:
 
 ```toml
 [dependencies]
-sei-cosmwasm = { version = "0.4.3" }
+sei-cosmwasm = { version = "0.4.4" }
 ```
 
 ## Functionality

--- a/packages/sei-cosmwasm/src/msg.rs
+++ b/packages/sei-cosmwasm/src/msg.rs
@@ -15,7 +15,7 @@ impl From<SeiMsg> for CosmosMsg<SeiMsg> {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SeiMsg {
     PlaceOrders {
@@ -42,7 +42,7 @@ pub enum SeiMsg {
     },
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SudoMsg {
     Settlement {

--- a/packages/sei-cosmwasm/src/proto_structs.rs
+++ b/packages/sei-cosmwasm/src/proto_structs.rs
@@ -4,34 +4,34 @@ use serde::{Deserialize, Serialize};
 use cosmwasm_std::{Decimal, Uint64};
 
 // ExchangeRateItem is data format returned from OracleRequest::ExchangeRates query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OracleExchangeRate {
     pub exchange_rate: Decimal,
     pub last_update: Uint64,
 }
 
 // ExchangeRateItem is data format returned from OracleRequest::ExchangeRates query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DenomOracleExchangeRatePair {
     pub denom: String,
     pub oracle_exchange_rate: OracleExchangeRate,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OracleTwap {
     pub denom: String,
     pub twap: Decimal,
     pub lookback_seconds: i64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DexPair {
     pub price_denom: String,
     pub asset_denom: String,
     pub tick_size: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DexTwap {
     pub pair: DexPair,
     pub twap: Decimal,
@@ -39,7 +39,7 @@ pub struct DexTwap {
 }
 
 // Epoch is the struct that matches the data format of Epoch in Epoch Response
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Epoch {
     pub genesis_time: String, // represented as ISO8601 UTC
     pub duration: u64,        // Represented as nanos

--- a/packages/sei-cosmwasm/src/query.rs
+++ b/packages/sei-cosmwasm/src/query.rs
@@ -8,7 +8,7 @@ use crate::sei_types::OrderResponse;
 use crate::Order;
 
 /// SeiQueryWrapper is an override of QueryRequest::Custom to access Sei-specific modules
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct SeiQueryWrapper {
     pub route: SeiRoute,
@@ -19,7 +19,7 @@ pub struct SeiQueryWrapper {
 impl CustomQuery for SeiQueryWrapper {}
 
 /// SeiQuery is defines available query datas
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SeiQuery {
     ExchangeRates {},
@@ -52,55 +52,55 @@ pub enum SeiQuery {
 }
 
 /// ExchangeRatesResponse is data format returned from OracleRequest::ExchangeRates query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ExchangeRatesResponse {
     pub denom_oracle_exchange_rate_pairs: Vec<DenomOracleExchangeRatePair>,
 }
 
 /// OracleTwapsResponse is data format returned from OracleRequest::OracleTwaps query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OracleTwapsResponse {
     pub oracle_twaps: Vec<OracleTwap>,
 }
 
 /// DexTwapsResponse is data format returned from DexTwaps query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DexTwapsResponse {
     pub twaps: Vec<DexTwap>,
 }
 
 /// EpochResponse is data format returned from Epoch query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct EpochResponse {
     pub epoch: Epoch,
 }
 
 /// GetOrdersResponse is data format returned from GetOrders query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetOrdersResponse {
     pub orders: Vec<OrderResponse>,
 }
 
 /// GetOrderdByIdResponse is data format returned from GetOrderById query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetOrderByIdResponse {
     pub order: OrderResponse,
 }
 
 /// OrderSimulationResponse is data format returned from OrderSimulation query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OrderSimulationResponse {
     pub executed_quantity: Decimal,
 }
 
 /// GetDenomFeeWhitelistResponse is data format returned from GetDenomFeeWhitelist query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct GetDenomFeeWhitelistResponse {
     pub creators: Vec<String>,
 }
 
 /// CreatorInDenomFeeWhitelistResponse is data format returned from CreatorInDenomFeeWhitelist query
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct CreatorInDenomFeeWhitelistResponse {
     pub whitelisted: bool,
 }

--- a/packages/sei-cosmwasm/src/route.rs
+++ b/packages/sei-cosmwasm/src/route.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// SeiRoute is enum type to represent sei query route path
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum SeiRoute {
     Oracle,

--- a/packages/sei-cosmwasm/src/sei_types.rs
+++ b/packages/sei-cosmwasm/src/sei_types.rs
@@ -79,12 +79,6 @@ pub struct OrderExecutionResult {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct MsgPlaceOrdersResponse {
-    pub order_ids: Vec<u64>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct SettlementEntry {
     pub account: String,
     pub price_denom: String,

--- a/packages/sei-cosmwasm/src/sei_types.rs
+++ b/packages/sei-cosmwasm/src/sei_types.rs
@@ -28,7 +28,7 @@ pub enum OrderStatus {
     Fulfilled = 3,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct Order {
     pub price: Decimal,
@@ -41,7 +41,7 @@ pub struct Order {
     pub status_description: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct OrderResponse {
     pub id: u64,
@@ -56,20 +56,20 @@ pub struct OrderResponse {
 }
 
 // The following are the types used in the sudo response for finalize block
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ContractOrderResult {
     pub contract_address: String,
     pub order_placement_results: Vec<OrderPlacementResult>,
     pub order_execution_results: Vec<OrderExecutionResult>,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OrderPlacementResult {
     pub order_id: u64,
     pub status_code: i32,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct OrderExecutionResult {
     pub order_id: u64,
     pub execution_price: Decimal,
@@ -78,7 +78,13 @@ pub struct OrderExecutionResult {
     pub position_direction: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct MsgPlaceOrdersResponse {
+    pub order_ids: Vec<u64>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct SettlementEntry {
     pub account: String,
     pub price_denom: String,
@@ -91,31 +97,31 @@ pub struct SettlementEntry {
     pub order_id: u64,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DepositInfo {
     pub account: String,
     pub denom: String,
     pub amount: Decimal,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct LiquidationRequest {
     pub requestor: String,
     pub account: String,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 pub struct LiquidationResponse {
     pub successful_accounts: Vec<String>,
     pub liquidation_orders: Vec<Order>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 pub struct BulkOrderPlacementsResponse {
     pub unsuccessful_orders: Vec<UnsuccessfulOrder>,
 }
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 pub struct UnsuccessfulOrder {
     pub id: u64,
     pub reason: String,


### PR DESCRIPTION
This PR removes #derive(Eq) so dependent packages no longer need to bump cosmwasm-std version.

Also temporarily changed cargo clippy setting from `-D warnings` to `-W warnings` as https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq is giving false positive checks.