### PR TITLE
[deps] Fix integration tests to be dev deps and not build on wasm target

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,4 @@
+[alias]
+wasm = "build --release --target wasm32-unknown-unknown"
+unit-test = "test --lib"
+schema = "run --example schema"

--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -29,6 +29,13 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
+      - name: Compile WASM contract
+        uses: actions-rs/cargo@v1
+        with:
+          command: wasm
+        env:
+          RUSTFLAGS: "-C link-arg=-s"
+
   lints:
     name: Lints
     runs-on: ubuntu-latest

--- a/packages/sei-integration-tests/Cargo.toml
+++ b/packages/sei-integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ description = "Custom module to support integration tests for Sei chain contract
 license = "Apache-2.0"
 readme = "README.md"
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 cw-multi-test = "0.14.0"
 anyhow = "1"
 sei-cosmwasm = { path = "../sei-cosmwasm", version = "0.4.9" }

--- a/packages/sei-integration-tests/Cargo.toml
+++ b/packages/sei-integration-tests/Cargo.toml
@@ -6,7 +6,7 @@ description = "Custom module to support integration tests for Sei chain contract
 license = "Apache-2.0"
 readme = "README.md"
 
-[dependencies]
+[dev-dependencies]
 cw-multi-test = "0.14.0"
 anyhow = "1"
 sei-cosmwasm = { path = "../sei-cosmwasm", version = "0.4.9" }

--- a/packages/sei-integration-tests/src/lib.rs
+++ b/packages/sei-integration-tests/src/lib.rs
@@ -1,5 +1,5 @@
 // Exposed for testing only
 // Both unit tests and integration tests are compiled to native code, so everything in here does not need to compile to Wasm.
-#[cfg(not(target_arch = "wasm32"))]
+#![cfg(not(target_arch = "wasm32"))]
 pub mod helper;
 pub mod module;


### PR DESCRIPTION
This fixes the issue of errors when building wasm release target, and reintroduces the wasm target as a CI build.