### PR TITLE
Change Oracle Lookback Seconds to Uint

### DIFF
--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -402,7 +402,7 @@ pub fn query_exchange_rates(deps: Deps<SeiQueryWrapper>) -> StdResult<ExchangeRa
 
 pub fn query_oracle_twaps(
     deps: Deps<SeiQueryWrapper>,
-    lookback_seconds: i64,
+    lookback_seconds: u64,
 ) -> StdResult<OracleTwapsResponse> {
     let querier = SeiQuerier::new(&deps.querier);
     let res: OracleTwapsResponse = querier.query_oracle_twaps(lookback_seconds)?;

--- a/contracts/sei-tester/src/msg.rs
+++ b/contracts/sei-tester/src/msg.rs
@@ -21,7 +21,7 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
     ExchangeRates {},
     OracleTwaps {
-        lookback_seconds: i64,
+        lookback_seconds: u64,
     },
     DexTwaps {
         contract_address: String,

--- a/packages/sei-cosmwasm/src/proto_structs.rs
+++ b/packages/sei-cosmwasm/src/proto_structs.rs
@@ -21,7 +21,7 @@ pub struct DenomOracleExchangeRatePair {
 pub struct OracleTwap {
     pub denom: String,
     pub twap: Decimal,
-    pub lookback_seconds: i64,
+    pub lookback_seconds: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/packages/sei-cosmwasm/src/querier.rs
+++ b/packages/sei-cosmwasm/src/querier.rs
@@ -31,7 +31,7 @@ impl<'a> SeiQuerier<'a> {
         self.querier.query(&request)
     }
 
-    pub fn query_oracle_twaps(&self, lookback_seconds: i64) -> StdResult<OracleTwapsResponse> {
+    pub fn query_oracle_twaps(&self, lookback_seconds: u64) -> StdResult<OracleTwapsResponse> {
         let request = SeiQueryWrapper {
             route: SeiRoute::Oracle,
             query_data: SeiQuery::OracleTwaps { lookback_seconds },

--- a/packages/sei-cosmwasm/src/query.rs
+++ b/packages/sei-cosmwasm/src/query.rs
@@ -24,7 +24,7 @@ impl CustomQuery for SeiQueryWrapper {}
 pub enum SeiQuery {
     ExchangeRates {},
     OracleTwaps {
-        lookback_seconds: i64,
+        lookback_seconds: u64,
     },
     DexTwaps {
         contract_address: Addr,

--- a/packages/sei-integration-tests/src/module.rs
+++ b/packages/sei-integration-tests/src/module.rs
@@ -423,7 +423,7 @@ fn get_exchange_rates(
 fn get_oracle_twaps(
     block: &BlockInfo,
     rates: HashMap<String, Vec<DenomOracleExchangeRatePair>>,
-    lookback_seconds: i64,
+    lookback_seconds: u64,
 ) -> OracleTwapsResponse {
     let mut oracle_twaps: Vec<OracleTwap> = Vec::new();
     let lbs = lookback_seconds as u64;


### PR DESCRIPTION
NOTE: Relies on sei-chain changes here: https://github.com/sei-protocol/sei-chain/pull/582
- Changes oracle lookback seconds to uint for consistency with dex twap lookback seconds

Tested with `sei-tester` e2e