### PR TITLE
Update Sei Tester Metadata Denoms + Queries

### DIFF
--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -186,17 +186,17 @@ pub fn set_metadata(
     env: Env,
     _info: MessageInfo,
 ) -> Result<Response<SeiMsg>, StdError> {
+    let tokenfactory_denom =
+        "factory/".to_string() + env.contract.address.to_string().as_ref() + "/subdenom";
     let test_metadata = Metadata {
         description: "Token Metadata".to_string(),
-        base: "factory/".to_string() + env.contract.address.to_string().as_ref() + "/subdenom",
+        base: tokenfactory_denom.clone(),
         display: "SUBDENOM".to_string(),
         name: "subdenom".to_string(),
         symbol: "SUB".to_string(),
         denom_units: vec![
             DenomUnit {
-                denom: "factory/".to_string()
-                    + env.contract.address.to_string().as_ref()
-                    + "/subdenom",
+                denom: tokenfactory_denom.clone(),
                 exponent: 0 as u32,
                 aliases: vec!["usubdenom".to_string()],
             },

--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -10,12 +10,12 @@ use crate::{
 };
 use protobuf::Message;
 use sei_cosmwasm::{
-    BulkOrderPlacementsResponse, ContractOrderResult, DenomAuthorityMetadataResponse,
-    Metadata, DenomUnit, DenomsFromCreatorResponse, DepositInfo, DexTwapsResponse,
-    EpochResponse, ExchangeRatesResponse, GetLatestPriceResponse, GetOrderByIdResponse,
-    GetOrdersResponse, LiquidationRequest, LiquidationResponse, MsgPlaceOrdersResponse,
-    OracleTwapsResponse, Order, OrderSimulationResponse, OrderType, PositionDirection, SeiMsg,
-    SeiQuerier, SeiQueryWrapper, SettlementEntry, SudoMsg,
+    BulkOrderPlacementsResponse, ContractOrderResult, DenomAuthorityMetadataResponse, DenomUnit,
+    DenomsFromCreatorResponse, DepositInfo, DexTwapsResponse, EpochResponse, ExchangeRatesResponse,
+    GetLatestPriceResponse, GetOrderByIdResponse, GetOrdersResponse, LiquidationRequest,
+    LiquidationResponse, Metadata, MsgPlaceOrdersResponse, OracleTwapsResponse, Order,
+    OrderSimulationResponse, OrderType, PositionDirection, SeiMsg, SeiQuerier, SeiQueryWrapper,
+    SettlementEntry, SudoMsg,
 };
 
 const PLACE_ORDER_REPLY_ID: u64 = 1;
@@ -194,14 +194,16 @@ pub fn set_metadata(
         symbol: "SUB".to_string(),
         denom_units: vec![
             DenomUnit {
+                denom: "factory/".to_string()
+                    + env.contract.address.to_string().as_ref()
+                    + "/subdenom",
+                exponent: 0 as u32,
+                aliases: vec!["usubdenom".to_string()],
+            },
+            DenomUnit {
                 denom: "SUBDENOM".to_string(),
                 exponent: 6 as u32,
                 aliases: vec!["subdenom".to_string()],
-            },
-            DenomUnit {
-                denom: "factory/".to_string() + env.contract.address.to_string().as_ref() + "/subdenom",
-                exponent: 0 as u32,
-                aliases: vec!["usubdenom".to_string()],
             },
         ],
     };

--- a/contracts/sei-tester/src/contract.rs
+++ b/contracts/sei-tester/src/contract.rs
@@ -183,25 +183,25 @@ pub fn change_admin(
 // set coin metadata for a tokenfactory denom.
 pub fn set_metadata(
     _deps: DepsMut<SeiQueryWrapper>,
-    _env: Env,
+    env: Env,
     _info: MessageInfo,
 ) -> Result<Response<SeiMsg>, StdError> {
     let test_metadata = Metadata {
         description: "Token Metadata".to_string(),
-        base: "token".to_string(),
-        display: "TOKEN".to_string(),
-        name: "token_name".to_string(),
-        symbol: "TOKEN".to_string(),
+        base: "factory/".to_string() + env.contract.address.to_string().as_ref() + "/subdenom",
+        display: "SUBDENOM".to_string(),
+        name: "subdenom".to_string(),
+        symbol: "SUB".to_string(),
         denom_units: vec![
             DenomUnit {
-                denom: "token1".to_string(),
+                denom: "SUBDENOM".to_string(),
                 exponent: 6 as u32,
-                aliases: vec!["microtoken1".to_string(), "token1".to_string()],
+                aliases: vec!["subdenom".to_string()],
             },
             DenomUnit {
-                denom: "token".to_string(),
+                denom: "factory/".to_string() + env.contract.address.to_string().as_ref() + "/subdenom",
                 exponent: 0 as u32,
-                aliases: vec!["token".to_string()],
+                aliases: vec!["usubdenom".to_string()],
             },
         ],
     };

--- a/packages/sei-cosmwasm/README.md
+++ b/packages/sei-cosmwasm/README.md
@@ -42,9 +42,9 @@ Currently, Sei Bindings support query and message support for the sei custom mod
             - Get current epoch information
 - TokenFactory
     - Query
-        - GetDenomAuthorityMetadata
+        - DenomAuthorityMetadata
             - Gets the denom authority metadata for a tokenfactory denom
-        - GetDenomsFromCreator
+        - DenomsFromCreator
             - Gets all the tokenfactory denoms from a creator
     - Message
         - CreateDenom

--- a/packages/sei-cosmwasm/src/lib.rs
+++ b/packages/sei-cosmwasm/src/lib.rs
@@ -18,8 +18,8 @@ pub use query::{
 };
 pub use route::SeiRoute;
 pub use sei_types::{
-    BulkOrderPlacementsResponse, ContractOrderResult, Metadata, DenomUnit, DepositInfo,
-    LiquidationRequest, LiquidationResponse, Order, OrderExecutionResult, OrderPlacementResult,
+    BulkOrderPlacementsResponse, ContractOrderResult, DenomUnit, DepositInfo, LiquidationRequest,
+    LiquidationResponse, Metadata, Order, OrderExecutionResult, OrderPlacementResult,
     OrderResponse, OrderStatus, OrderType, PositionDirection, SettlementEntry,
 };
 pub use tx::MsgPlaceOrdersResponse;

--- a/packages/sei-cosmwasm/src/msg.rs
+++ b/packages/sei-cosmwasm/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::sei_types::{
-    ContractOrderResult, Metadata, DepositInfo, LiquidationRequest, Order, SettlementEntry,
+    ContractOrderResult, DepositInfo, LiquidationRequest, Metadata, Order, SettlementEntry,
 };
 use cosmwasm_std::{Addr, Coin, CosmosMsg, CustomMsg};
 use schemars::JsonSchema;

--- a/packages/sei-cosmwasm/src/querier.rs
+++ b/packages/sei-cosmwasm/src/querier.rs
@@ -153,7 +153,7 @@ impl<'a> SeiQuerier<'a> {
     ) -> StdResult<DenomAuthorityMetadataResponse> {
         let request = SeiQueryWrapper {
             route: SeiRoute::Tokenfactory,
-            query_data: SeiQuery::GetDenomAuthorityMetadata { denom },
+            query_data: SeiQuery::DenomAuthorityMetadata { denom },
         }
         .into();
         self.querier.query(&request)
@@ -162,7 +162,7 @@ impl<'a> SeiQuerier<'a> {
     pub fn query_denoms_from_creator(&self, creator: Addr) -> StdResult<DenomsFromCreatorResponse> {
         let request = SeiQueryWrapper {
             route: SeiRoute::Tokenfactory,
-            query_data: SeiQuery::GetDenomsFromCreator { creator },
+            query_data: SeiQuery::DenomsFromCreator { creator },
         }
         .into();
         self.querier.query(&request)

--- a/packages/sei-cosmwasm/src/query.rs
+++ b/packages/sei-cosmwasm/src/query.rs
@@ -50,10 +50,10 @@ pub enum SeiQuery {
         contract_address: Addr,
         order: Order,
     },
-    GetDenomAuthorityMetadata {
+    DenomAuthorityMetadata {
         denom: String,
     },
-    GetDenomsFromCreator {
+    DenomsFromCreator {
         creator: Addr,
     },
 }
@@ -115,13 +115,13 @@ pub struct OrderSimulationResponse {
     pub executed_quantity: Decimal,
 }
 
-/// DenomAuthorityMetadataResponse is data format returned from GetDenomAuthorityMetadata query
+/// DenomAuthorityMetadataResponse is data format returned from DenomAuthorityMetadata query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DenomAuthorityMetadataResponse {
     pub authority_metadata: DenomAuthorityMetadata,
 }
 
-/// DenomsFromCreatorResponse is data format returned from GetDenomsFromCreator query
+/// DenomsFromCreatorResponse is data format returned from DenomsFromCreator query
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct DenomsFromCreatorResponse {
     pub denoms: Vec<String>,

--- a/packages/sei-integration-tests/src/module.rs
+++ b/packages/sei-integration-tests/src/module.rs
@@ -188,11 +188,11 @@ impl Module for SeiModule {
                 );
             }
             // TODO: Implement get denom authority metadata in integration tests
-            SeiQuery::GetDenomAuthorityMetadata { .. } => {
+            SeiQuery::DenomAuthorityMetadata { .. } => {
                 panic!("Denom Authority Metadata not implemented")
             }
             // TODO: Implement get denom from creator in integration tests
-            SeiQuery::GetDenomsFromCreator { .. } => {
+            SeiQuery::DenomsFromCreator { .. } => {
                 panic!("Denoms From Creator not implemented")
             }
         }


### PR DESCRIPTION
- Updates Sei Tester SetMetadata call to use "subdenom" + full tokenfactory denoms
- Also ran another `cargo fmt` 
- Removes the query naming scheme with Get (GetDenomMetadata => DenomMetadata),  since we are not going to merge https://github.com/sei-protocol/sei-chain/pull/1004 

**Testing**
Verified on chain: 
```seid q bank denom-metadata --denom factory/sei1xznecenkdln0clw7weeee7fh9xg44ercarv5j3ms39d0zxeu9dgs8fr5vf/subdenom
metadata:
  base: factory/sei1xznecenkdln0clw7weeee7fh9xg44ercarv5j3ms39d0zxeu9dgs8fr5vf/subdenom
  denom_units:
  - aliases:
    - usubdenom
    denom: factory/sei1xznecenkdln0clw7weeee7fh9xg44ercarv5j3ms39d0zxeu9dgs8fr5vf/subdenom
    exponent: 0
  - aliases:
    - subdenom
    denom: SUBDENOM
    exponent: 6
  description: Token Metadata
  display: SUBDENOM
  name: subdenom
  symbol: SUB```

```seid q wasm contract-state smart sei1a8grtl3r7e2t68gc80x4zmkp8wycrzku4ffdknd2q9477t2tl70qxs7qr0 '{"get_denoms_from_creator": {"creator": "sei1a8grtl3r7e2t68gc80x4zmkp8wycrzku4ffdknd2q9477t2tl70qxs7qr0"}}'
data:
  denoms:
- factory/sei1a8grtl3r7e2t68gc80x4zmkp8wycrzku4ffdknd2q9477t2tl70qxs7qr0/subdenom```
```seid q wasm contract-state smart sei1a8grtl3r7e2t68gc80x4zmkp8wycrzku4ffdknd2q9477t2tl70qxs7qr0 '{"get_denom_authority_metadata": {"denom": "factory/sei1a8grtl3r7e2t68gc80x4zmkp8wycrzku4ffdknd2q9477t2tl70qxs7qr0/subdenom"}}'
data:
  authority_metadata:
*     admin: sei1a8grtl3r7e2t68gc80x4zmkp8wycrzku4ffdknd2q9477t2tl70qxs7qr0```